### PR TITLE
Added a call to generateACRNFrequencies(); at the start of playACRN()

### DIFF
--- a/js/ACRN.js
+++ b/js/ACRN.js
@@ -174,7 +174,6 @@ function setFrequencyUpdateACRN(value) {
     generateACRNFrequencies();
     renderACRNFrequencies();
     resetFreqVolumes();
-
 }
 
 function setFrequency(freq) {
@@ -293,6 +292,7 @@ function playACRN() {
     }
 
     if (currentState !== states.PLAY_ACRN) {
+        generateACRNFrequencies();
         // start timer
         timer.resetStopwatch();
         timer.Timer.play();


### PR DESCRIPTION
This fixes the issue where if you load the page for the first time, ACRN does not work until you move the slider slightly.
