### PR TITLE
Fixed shri's attempted PR #11 to play ACRN on left or right only

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ ACRN = Acoustic Coordinated Reset Neuromodulation
 ====
 
 This is an implementation of the Acoustic Coordinated Reset Neuromodulation tinnitus treatment protocol in javascript.
-I'm currently hosting it on my [website](http://www.generalfuzz.net/acrn/).
+You can try it out [here](https://petervermont.github.io/acrn/).
 
 Feel free to fix any bugs you find or add features.
 

--- a/index.html
+++ b/index.html
@@ -107,7 +107,9 @@
             <br/>
             <section id="play">
                 <button type="button" class="btn btn-default" id="playToneButton" onclick="playTone();">Play Single Frequency</button>
-                <button type="button" class="btn btn-default" id="playACRNButton" onclick="playACRN();">Play ACRN</button>
+                <button type="button" class="btn btn-default" id="playACRNButton" onclick="playACRN(0.5);">Play ACRN</button>
+                <button type="button" class="btn btn-default" id="playLeft" onclick="playACRN(0);">Play ACRN Only Left</button>
+                <button type="button" class="btn btn-default" id="playRight" onclick="playACRN(1);">Play ACRN Only Right</button>
                 <button type="button" class="btn btn-default" id="stopButton" onclick="stop();">Stop Audio</button>
             </section>
             <br/>

--- a/js/ACRN.js
+++ b/js/ACRN.js
@@ -286,10 +286,11 @@ function highlightCurrentFreq() {
     $("#" + ACRN_FREQ_PREFIX + currentPlayingFreqIndex).addClass("acrnFreqPlaying");
 }
 
-function playACRN() {
-    if (currentState === states.PLAY_TONE) {
+function playACRN(pan) {
+    if (currentState === states.PLAY_TONE || currentState == states.PLAY_ACRN) {
         stop();
     }
+
 
     if (currentState !== states.PLAY_ACRN) {
         generateACRNFrequencies();
@@ -301,9 +302,11 @@ function playACRN() {
         // High synth - scheduled as a mono synth (i.e. one instance keeps
         // running and the gate and frequency are switched)
         this.synth = new TriggerSynth(audiolet, this.currentFreq);
+        this.pan = new Pan(audiolet, pan);
 
         // Connect it to the output so we can hear it
-        this.synth.connect(audiolet.output);
+        this.synth.connect(this.pan);
+        this.pan.connect(audiolet.output);
 
         // first set the gate on the ADSR envelope to 1, then alternate to 0 
         // trigger release
@@ -362,9 +365,9 @@ function generateACRNFrequencies() {
     freqChoices = [Math.floor(currentFreq * 0.773 - 44.5), Math.floor(currentFreq * 0.903 - 21.5),
         Math.floor(currentFreq * 1.09 + 52), Math.floor(currentFreq * 1.395 + 26.5)];
     for (var i = 0; i < numFreqs; i++) {
-    	freqVolumes[i] = defaultFreqVolume;
-    	if (localStorage.getItem(ACRN_FREQ_PREFIX + "vol" + i)) // load in saved volume for frequency-slot, if one exists
-    		freqVolumes[i] = localStorage.getItem(ACRN_FREQ_PREFIX + "vol" + i);
+        freqVolumes[i] = defaultFreqVolume;
+        if (localStorage.getItem(ACRN_FREQ_PREFIX + "vol" + i)) // load in saved volume for frequency-slot, if one exists
+            freqVolumes[i] = localStorage.getItem(ACRN_FREQ_PREFIX + "vol" + i);
     }
     if (Modernizr.localstorage) {
         for (var i = 0; i < numFreqs; i++) {

--- a/js/ACRN.js
+++ b/js/ACRN.js
@@ -416,8 +416,13 @@ function stop() {
             audiolet.scheduler.stop();
         }
         // Connect it to the output so we can hear it
-        this.synth.disconnect(this.pan);
-        this.pan.disconnect(audiolet.output);
+        if(currentState === states.PLAY_TONE) {
+            this.synth.disconnect(audiolet.output);
+        } else {
+            this.synth.disconnect(this.pan);
+            this.pan.disconnect(audiolet.output);
+        }
+        
         currentState = states.STOP;
         timer.Timer.pause();
     }

--- a/js/ACRN.js
+++ b/js/ACRN.js
@@ -416,7 +416,8 @@ function stop() {
             audiolet.scheduler.stop();
         }
         // Connect it to the output so we can hear it
-        this.synth.disconnect(audiolet.output);
+        this.synth.disconnect(this.pan);
+        this.pan.disconnect(audiolet.output);
         currentState = states.STOP;
         timer.Timer.pause();
     }


### PR DESCRIPTION
UI is not perfect -- the new toggling behavior does not know about the three modes of playing ACRN (both, left, or right) and treats them as all the same in terms of toggling. If one only uses the 'Play ACRN' button the behavior is identical to before.